### PR TITLE
maintain color in output

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const gaze = require('gaze');
 const _ = require('lodash');
 
 const exec = require('child_process').exec;
+const supportsColor = require('supports-color');
+const childEnv = _.assign({
+  FORCE_COLOR: supportsColor ? 1 : undefined
+}, process.env)
 
 var strip = function (str) {
   var re = /^=(.*)$/;
@@ -25,7 +29,7 @@ var watch = function (options) {
 
   var runCmd = function(cmd, cb) {
     log.write('Running ' + cmd);
-    var cp = exec(cmd, {}, function(err, stdout, stderr) {
+    var cp = exec(cmd, { env: childEnv }, function(err, stdout, stderr) {
       if(err) {
         cb(err);
       } else {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gaze": "^0.5.1",
     "lodash": "^3.5.0",
     "minimist": "^1.1.1",
+    "supports-color": "^4.0.0",
     "verbalize": "^0.1.2"
   },
   "keywords": [


### PR DESCRIPTION
Use `support-color` package to determine whether the calling environment
supports color. If it does, FORCE_COLOR in the child_processes.

Closes #5