### PR TITLE
Make environment variables FILENAME and EVENT available from command

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -29,13 +29,13 @@ EVENT              Event type. Is either 'changed', 'deleted' or 'added'.
 Use it like this in Linux/macOS:
 
 ```
-$ watch **/*.js -c 'jshint $FILENAME'
+$ watch -p '**/*.js' -c 'jshint $FILENAME'
 ```
 
 In Windows:
 
 ```
-> watch **/*.js -c "jshint %FILENAME%"
+> watch -p "**/*.js" -c "jshint %FILENAME%"
 ```
 
 ## Author

--- a/.verb.md
+++ b/.verb.md
@@ -16,6 +16,28 @@ npm i -g watch-cli
 watch -p "**/*.js" -c "npm test"
 ```
 
+### Exported environment variables
+
+Environment variables available from the command string:
+
+```
+FILENAME           Relative filename.
+ABSOLUTE_FILENAME  Asolute filename.
+EVENT              Event type. Is either 'changed', 'deleted' or 'added'.
+```
+
+Use it like this in Linux/macOS:
+
+```
+$ watch **/*.js -c 'jshint $FILENAME'
+```
+
+In Windows:
+
+```
+> watch **/*.js -c "jshint %FILENAME%"
+```
+
 ## Author
 {%= include("author") %}
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ It is possible to provide multi paterns, so if one of the files changed, the com
 watch -p file1.js -p file2.fs -c command
 ```
 
+### Exported environment variables
+
+Environment variables available from the command string:
+
+```
+FILENAME           Relative filename.
+ABSOLUTE_FILENAME  Asolute filename.
+EVENT              Event type. Is either 'changed', 'deleted' or 'added'.
+```
+
+Use it like this in Linux/macOS:
+
+```
+$ watch '**/*.js' -c 'jshint $FILENAME'
+```
+
+In Windows:
+
+```
+> watch "**/*.js" -c "jshint %FILENAME%"
+```
+
 ## Author
 
 **Brian Woodward**

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ EVENT              Event type. Is either 'changed', 'deleted' or 'added'.
 Use it like this in Linux/macOS:
 
 ```
-$ watch '**/*.js' -c 'jshint $FILENAME'
+$ watch -p '**/*.js' -c 'jshint $FILENAME'
 ```
 
 In Windows:
 
 ```
-> watch "**/*.js" -c "jshint %FILENAME%"
+> watch -p "**/*.js" -c "jshint %FILENAME%"
 ```
 
 ## Author

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const log = require('verbalize');
 const gaze = require('gaze');
+const path = require('path');
+const process = require('process');
 const _ = require('lodash');
 
 const exec = require('child_process').exec;
@@ -27,9 +29,13 @@ var watch = function (options) {
     child.pipe(output);
   };
 
-  var runCmd = function(cmd, cb) {
+  var runCmd = function(cmd, filepath, event, cb) {
     log.write('Running ' + cmd);
-    var cp = exec(cmd, { env: childEnv }, function(err, stdout, stderr) {
+    var env = childEnv;
+    env.ABSOLUTE_FILENAME = filepath;
+    env.FILENAME = path.relative(process.cwd(), filepath);
+    env.EVENT = event;
+    var cp = exec(cmd, { env: env }, function(err, stdout, stderr) {
       if(err) {
         cb(err);
       } else {
@@ -59,7 +65,7 @@ var watch = function (options) {
           lastEvent = now;
           return;
         }
-        runCmd(command, function (err) {
+        runCmd(command, filepath, event, function (err) {
           running = false;
           log.write('Finished ' + command);
           log.write('Watching started');


### PR DESCRIPTION
Environment variables available from the command string:

```
FILENAME           Relative filename.
ABSOLUTE_FILENAME  Asolute filename.
EVENT              Event type. Is either 'changed', 'deleted' or 'added'.
```

Use it like this in Linux/macOS:

```
$ watch -p '**/*.js' -c 'jshint $FILENAME'
```

In Windows:

```
> watch -p "**/*.js" -c "jshint %FILENAME%"
```

This feature was copied from my Ruby gem filewatcher https://github.com/thomasfl/filewatcher